### PR TITLE
[OPS] Add helm charts to nomad

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: nomad
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/templates/nomad.yaml
+++ b/templates/nomad.yaml
@@ -1,0 +1,37 @@
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app: "nomad"
+  name: "nomad"
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    app: "nomad"
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: "nomad"
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: "nomad"  
+  replicas: 1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: "nomad"
+    spec:
+      containers:
+      - image: "nomad_dev"
+        command: ["poetry","run", "uvicorn", "nomad.main:app", "--reload", "--host=0.0.0.0"]
+        imagePullPolicy: IfNotPresent
+        name: "nomad"
+        ports:
+        - containerPort: 8000
+      restartPolicy: Always

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,1 @@
+# Default values for nomad.


### PR DESCRIPTION
Create helm chart of the project to deploy the project easily on a kubernetes environment

```
(base) ➜  nomad git:(master) ✗ helm install nomad . --debug
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/goutham.pratapa/Work/wip/ppdp/tools/k3s/kubeconfig.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/goutham.pratapa/Work/wip/ppdp/tools/k3s/kubeconfig.yaml
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /Users/goutham.pratapa/Work/ownwork/temp/nomad

client.go:122: [debug] creating 2 resource(s)
NAME: nomad
LAST DEPLOYED: Mon Jan 24 09:38:04 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
USER-SUPPLIED VALUES:
{}

COMPUTED VALUES:
{}

HOOKS:
MANIFEST:
---
# Source: nomad/templates/nomad.yaml
kind: Service
apiVersion: v1
metadata:
  labels:
    app: "nomad"
  name: "nomad"
spec:
  ports:
  - port: 8000
    targetPort: 8000
  selector:
    app: "nomad"
---
# Source: nomad/templates/nomad.yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: "nomad"
  namespace: default
spec:
  selector:
    matchLabels:
      app: "nomad"
  replicas: 1
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: "nomad"
    spec:
      containers:
      - image: "nomad_dev"
        command: ["poetry","run", "uvicorn", "nomad.main:app", "--reload", "--host=0.0.0.0"]
        imagePullPolicy: IfNotPresent
        name: "nomad"
        ports:
        - containerPort: 8000
      restartPolicy: Always
```
<img width="941" alt="Screenshot 2022-01-24 at 9 39 17 AM" src="https://user-images.githubusercontent.com/15846947/150720716-97d9ee89-82a0-4eb9-9786-39baeecd55f3.png">
