### PR TITLE
[infra] Add infra to setup eks cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ test-results
 yarn-error.log
 __pycache__
 *.terraform.lock.hcl
-*.terraform
+*.terraform*
 *.tfstate

--- a/infra/stack/eks.tf
+++ b/infra/stack/eks.tf
@@ -1,0 +1,69 @@
+module "label" {
+  source = "cloudposse/label/null"
+
+  name       = var.label_name
+  attributes = ["cluster"]
+}
+
+locals {
+  # Prior to Kubernetes 1.19, the usage of the specific kubernetes.io/cluster/* resource tags below are required
+  # for EKS and Kubernetes to discover and manage networking resources
+  # https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html#base-vpc-networking
+  tags = { "kubernetes.io/cluster/${module.label.id}" = "shared" }
+}
+
+module "vpc" {
+  source = "cloudposse/vpc/aws"
+
+  cidr_block = "172.16.0.0/16"
+
+  tags    = local.tags
+  context = module.label.context
+}
+
+module "subnets" {
+  source = "cloudposse/dynamic-subnets/aws"
+
+  availability_zones   = var.availability_zones
+  vpc_id               = module.vpc.vpc_id
+  igw_id               = module.vpc.igw_id
+  cidr_block           = module.vpc.vpc_cidr_block
+  nat_gateway_enabled  = true
+  nat_instance_enabled = false
+
+  tags    = local.tags
+  context = module.label.context
+}
+
+module "eks_cluster" {
+  source = "cloudposse/eks-cluster/aws"
+  region = var.region
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.subnets.public_subnet_ids
+
+  kubernetes_version    = var.kubernetes_version
+  oidc_provider_enabled = true
+
+  context = module.label.context
+}
+
+module "eks_node_group" {
+  source = "cloudposse/eks-node-group/aws"
+
+  instance_types        = [var.instance_type]
+  desired_size          = var.desired_size
+  subnet_ids            = module.subnets.public_subnet_ids
+  min_size              = var.min_size
+  max_size              = var.max_size
+  cluster_name          = module.eks_cluster.eks_cluster_id
+  create_before_destroy = true
+  kubernetes_version    = var.kubernetes_version == null || var.kubernetes_version == "" ? [] : [var.kubernetes_version]
+
+  # Enable the Kubernetes cluster auto-scaler to find the auto-scaling group
+
+  context = module.label.context
+
+  # Ensure the cluster is fully created before trying to add the node group
+  module_depends_on = [module.eks_cluster.kubernetes_config_map_id]
+}

--- a/infra/stack/tfvars/values.tfvars
+++ b/infra/stack/tfvars/values.tfvars
@@ -1,0 +1,8 @@
+label_name          = "nomad"
+region              = "ap-south-1"
+kubernetes_version  = "1.21"
+desired_size        = 1
+instance_type       = "t2.small"
+min_size            = 1
+max_size            = 1
+availability_zones  = ["ap-south-1a", "ap-south-1b"]

--- a/infra/stack/variables.tf
+++ b/infra/stack/variables.tf
@@ -1,0 +1,31 @@
+variable "label_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "kubernetes_version" {
+  type = string
+}
+
+variable "desired_size" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "min_size" {
+  type = string
+}
+
+variable "max_size" {
+  type = string
+}
+
+variable "availability_zones"{
+  type = list
+}

--- a/infra/stack/versions.tf
+++ b/infra/stack/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+  required_version = ">= 0.14.9"
+}
+
+provider "aws" {
+  region = "ap-south-1"
+}


### PR DESCRIPTION
Add infra to create a eks cluster

Following is the output of ```terraform plan```

```
root@9154ebe8e74e:~/nomad/infra/stack# terraform apply -var-file tfvars/values.tfvars -auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # module.eks_cluster.data.aws_eks_cluster_auth.eks[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_eks_cluster_auth" "eks"  {
      + id    = (known after apply)
      + name  = (known after apply)
      + token = (sensitive value)
    }

  # module.eks_cluster.data.tls_certificate.cluster[0] will be read during apply
  # (config refers to values not yet known)
 <= data "tls_certificate" "cluster"  {
      + certificates = (known after apply)
      + id           = (known after apply)
      + url          = (known after apply)
    }

  # module.eks_cluster.aws_eks_cluster.default[0] will be created
  + resource "aws_eks_cluster" "default" {
      + arn                   = (known after apply)
      + certificate_authority = (known after apply)
      + created_at            = (known after apply)
      + endpoint              = (known after apply)
      + id                    = (known after apply)
      + identity              = (known after apply)
      + name                  = "nomad-cluster"
      + platform_version      = (known after apply)
      + role_arn              = (known after apply)
      + status                = (known after apply)
      + tags                  = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + tags_all              = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + version               = "1.21"

      + encryption_config {
          + resources = [
              + "secrets",
            ]

          + provider {
              + key_arn = (known after apply)
            }
        }

      + kubernetes_network_config {
          + ip_family         = (known after apply)
          + service_ipv4_cidr = (known after apply)
        }

      + vpc_config {
          + cluster_security_group_id = (known after apply)
          + endpoint_private_access   = false
          + endpoint_public_access    = true
          + public_access_cidrs       = [
              + "0.0.0.0/0",
            ]
          + subnet_ids                = (known after apply)
          + vpc_id                    = (known after apply)
        }
    }

  # module.eks_cluster.aws_iam_openid_connect_provider.default[0] will be created
  + resource "aws_iam_openid_connect_provider" "default" {
      + arn             = (known after apply)
      + client_id_list  = [
          + "sts.amazonaws.com",
        ]
      + id              = (known after apply)
      + tags            = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + tags_all        = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + thumbprint_list = (known after apply)
      + url             = (known after apply)
    }

  # module.eks_cluster.aws_iam_policy.cluster_elb_service_role[0] will be created
  + resource "aws_iam_policy" "cluster_elb_service_role" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "nomad-cluster-ServiceRole"
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "elasticloadbalancing:SetSubnets",
                          + "elasticloadbalancing:SetIpAddressType",
                          + "ec2:DescribeInternetGateways",
                          + "ec2:DescribeAddresses",
                          + "ec2:DescribeAccountAttributes",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "AllowElasticLoadBalancer"
                    },
                  + {
                      + Action   = "logs:CreateLogGroup"
                      + Effect   = "Deny"
                      + Resource = "*"
                      + Sid      = "DenyCreateLogGroup"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags_all  = (known after apply)
    }

  # module.eks_cluster.aws_iam_role.default[0] will be created
  + resource "aws_iam_role" "default" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "nomad-cluster"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags                  = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + tags_all              = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.eks_cluster.aws_iam_role_policy_attachment.amazon_eks_cluster_policy[0] will be created
  + resource "aws_iam_role_policy_attachment" "amazon_eks_cluster_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + role       = "nomad-cluster"
    }

  # module.eks_cluster.aws_iam_role_policy_attachment.amazon_eks_service_policy[0] will be created
  + resource "aws_iam_role_policy_attachment" "amazon_eks_service_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
      + role       = "nomad-cluster"
    }

  # module.eks_cluster.aws_iam_role_policy_attachment.cluster_elb_service_role[0] will be created
  + resource "aws_iam_role_policy_attachment" "cluster_elb_service_role" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "nomad-cluster"
    }

  # module.eks_cluster.aws_kms_alias.cluster[0] will be created
  + resource "aws_kms_alias" "cluster" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/nomad-cluster"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.eks_cluster.aws_kms_key.cluster[0] will be created
  + resource "aws_kms_key" "cluster" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "EKS Cluster nomad-cluster Encryption Config KMS Key"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags                               = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
      + tags_all                           = {
          + "Attributes" = "cluster"
          + "Name"       = "nomad-cluster"
        }
    }

  # module.eks_cluster.kubernetes_config_map.aws_auth_ignore_changes[0] will be created
  + resource "kubernetes_config_map" "aws_auth_ignore_changes" {
      + data = {
          + "mapAccounts" = jsonencode([])
          + "mapRoles"    = jsonencode([])
          + "mapUsers"    = jsonencode([])
        }
      + id   = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "aws-auth"
          + namespace        = "kube-system"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.eks_cluster.null_resource.wait_for_cluster[0] will be created
  + resource "null_resource" "wait_for_cluster" {
      + id = (known after apply)
    }

  # module.eks_node_group.aws_eks_node_group.cbd[0] will be created
  + resource "aws_eks_node_group" "cbd" {
      + ami_type               = "AL2_x86_64"
      + arn                    = (known after apply)
      + capacity_type          = (known after apply)
      + cluster_name           = (known after apply)
      + disk_size              = (known after apply)
      + id                     = (known after apply)
      + instance_types         = [
          + "t2.small",
        ]
      + node_group_name        = (known after apply)
      + node_group_name_prefix = (known after apply)
      + node_role_arn          = (known after apply)
      + release_version        = (known after apply)
      + resources              = (known after apply)
      + status                 = (known after apply)
      + subnet_ids             = (known after apply)
      + tags                   = (known after apply)
      + tags_all               = (known after apply)
      + version                = "1.21"

      + launch_template {
          + id      = (known after apply)
          + name    = (known after apply)
          + version = (known after apply)
        }

      + scaling_config {
          + desired_size = 1
          + max_size     = 1
          + min_size     = 1
        }

      + update_config {
          + max_unavailable            = (known after apply)
          + max_unavailable_percentage = (known after apply)
        }
    }

  # module.eks_node_group.aws_iam_role.default[0] will be created
  + resource "aws_iam_role" "default" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "nomad-cluster-workers"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags                  = {
          + "Attributes" = "cluster-workers"
          + "Name"       = "nomad-cluster-workers"
        }
      + tags_all              = {
          + "Attributes" = "cluster-workers"
          + "Name"       = "nomad-cluster-workers"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # module.eks_node_group.aws_iam_role_policy_attachment.amazon_ec2_container_registry_read_only[0] will be created
  + resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
      + role       = "nomad-cluster-workers"
    }

  # module.eks_node_group.aws_iam_role_policy_attachment.amazon_eks_cni_policy[0] will be created
  + resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
      + role       = "nomad-cluster-workers"
    }

  # module.eks_node_group.aws_iam_role_policy_attachment.amazon_eks_worker_node_policy[0] will be created
  + resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
      + role       = "nomad-cluster-workers"
    }

  # module.eks_node_group.aws_launch_template.default[0] will be created
  + resource "aws_launch_template" "default" {
      + arn                    = (known after apply)
      + default_version        = (known after apply)
      + ebs_optimized          = "false"
      + id                     = (known after apply)
      + latest_version         = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "nomad-cluster-workers"
      + tags                   = (known after apply)
      + tags_all               = (known after apply)
      + update_default_version = true

      + block_device_mappings {
          + device_name = "/dev/xvda"

          + ebs {
              + delete_on_termination = "true"
              + encrypted             = "true"
              + iops                  = (known after apply)
              + throughput            = (known after apply)
              + volume_size           = 20
              + volume_type           = "gp2"
            }
        }

      + metadata_options {
          + http_endpoint               = "enabled"
          + http_protocol_ipv6          = "disabled"
          + http_put_response_hop_limit = 2
          + http_tokens                 = "required"
          + instance_metadata_tags      = "disabled"
        }
    }

  # module.eks_node_group.random_pet.cbd[0] will be created
  + resource "random_pet" "cbd" {
      + id        = (known after apply)
      + keepers   = (known after apply)
      + length    = 1
      + separator = "-"
    }

  # module.subnets.data.aws_vpc.default[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_vpc" "default"  {
      + arn                     = (known after apply)
      + cidr_block              = (known after apply)
      + cidr_block_associations = (known after apply)
      + default                 = (known after apply)
      + dhcp_options_id         = (known after apply)
      + enable_dns_hostnames    = (known after apply)
      + enable_dns_support      = (known after apply)
      + id                      = (known after apply)
      + instance_tenancy        = (known after apply)
      + ipv6_association_id     = (known after apply)
      + ipv6_cidr_block         = (known after apply)
      + main_route_table_id     = (known after apply)
      + owner_id                = (known after apply)
      + state                   = (known after apply)
      + tags                    = (known after apply)
    }

  # module.subnets.aws_eip.default[0] will be created
  + resource "aws_eip" "default" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1a"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all             = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1a"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc                  = true
    }

  # module.subnets.aws_eip.default[1] will be created
  + resource "aws_eip" "default" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags                 = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1b"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all             = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1b"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc                  = true
    }

  # module.subnets.aws_nat_gateway.default[0] will be created
  + resource "aws_nat_gateway" "default" {
      + allocation_id        = (known after apply)
      + connectivity_type    = "public"
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = {
          + "Attributes"                          = "cluster-nat"
          + "Name"                                = "nomad-cluster-nat-aps1a"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all             = {
          + "Attributes"                          = "cluster-nat"
          + "Name"                                = "nomad-cluster-nat-aps1a"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
    }

  # module.subnets.aws_nat_gateway.default[1] will be created
  + resource "aws_nat_gateway" "default" {
      + allocation_id        = (known after apply)
      + connectivity_type    = "public"
      + id                   = (known after apply)
      + network_interface_id = (known after apply)
      + private_ip           = (known after apply)
      + public_ip            = (known after apply)
      + subnet_id            = (known after apply)
      + tags                 = {
          + "Attributes"                          = "cluster-nat"
          + "Name"                                = "nomad-cluster-nat-aps1b"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all             = {
          + "Attributes"                          = "cluster-nat"
          + "Name"                                = "nomad-cluster-nat-aps1b"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
    }

  # module.subnets.aws_network_acl.private[0] will be created
  + resource "aws_network_acl" "private" {
      + arn        = (known after apply)
      + egress     = [
          + {
              + action          = "allow"
              + cidr_block      = "0.0.0.0/0"
              + from_port       = 0
              + icmp_code       = null
              + icmp_type       = null
              + ipv6_cidr_block = ""
              + protocol        = "-1"
              + rule_no         = 100
              + to_port         = 0
            },
        ]
      + id         = (known after apply)
      + ingress    = [
          + {
              + action          = "allow"
              + cidr_block      = "0.0.0.0/0"
              + from_port       = 0
              + icmp_code       = null
              + icmp_type       = null
              + ipv6_cidr_block = ""
              + protocol        = "-1"
              + rule_no         = 100
              + to_port         = 0
            },
        ]
      + owner_id   = (known after apply)
      + subnet_ids = (known after apply)
      + tags       = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all   = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id     = (known after apply)
    }

  # module.subnets.aws_network_acl.public[0] will be created
  + resource "aws_network_acl" "public" {
      + arn        = (known after apply)
      + egress     = [
          + {
              + action          = "allow"
              + cidr_block      = "0.0.0.0/0"
              + from_port       = 0
              + icmp_code       = null
              + icmp_type       = null
              + ipv6_cidr_block = ""
              + protocol        = "-1"
              + rule_no         = 100
              + to_port         = 0
            },
        ]
      + id         = (known after apply)
      + ingress    = [
          + {
              + action          = "allow"
              + cidr_block      = "0.0.0.0/0"
              + from_port       = 0
              + icmp_code       = null
              + icmp_type       = null
              + ipv6_cidr_block = ""
              + protocol        = "-1"
              + rule_no         = 100
              + to_port         = 0
            },
        ]
      + owner_id   = (known after apply)
      + subnet_ids = (known after apply)
      + tags       = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all   = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id     = (known after apply)
    }

  # module.subnets.aws_route.default[0] will be created
  + resource "aws_route" "default" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + nat_gateway_id         = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)

      + timeouts {
          + create = "2m"
          + delete = "5m"
        }
    }

  # module.subnets.aws_route.default[1] will be created
  + resource "aws_route" "default" {
      + destination_cidr_block = "0.0.0.0/0"
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + nat_gateway_id         = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)

      + timeouts {
          + create = "2m"
          + delete = "5m"
        }
    }

  # module.subnets.aws_route.public[0] will be created
  + resource "aws_route" "public" {
      + destination_cidr_block = "0.0.0.0/0"
      + gateway_id             = (known after apply)
      + id                     = (known after apply)
      + instance_id            = (known after apply)
      + instance_owner_id      = (known after apply)
      + network_interface_id   = (known after apply)
      + origin                 = (known after apply)
      + route_table_id         = (known after apply)
      + state                  = (known after apply)

      + timeouts {
          + create = "2m"
          + delete = "5m"
        }
    }

  # module.subnets.aws_route_table.private[0] will be created
  + resource "aws_route_table" "private" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1a"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all         = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1a"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id           = (known after apply)
    }

  # module.subnets.aws_route_table.private[1] will be created
  + resource "aws_route_table" "private" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1b"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all         = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1b"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id           = (known after apply)
    }

  # module.subnets.aws_route_table.public[0] will be created
  + resource "aws_route_table" "public" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = (known after apply)
      + tags             = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all         = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id           = (known after apply)
    }

  # module.subnets.aws_route_table_association.private[0] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.subnets.aws_route_table_association.private[1] will be created
  + resource "aws_route_table_association" "private" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.subnets.aws_route_table_association.public[0] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.subnets.aws_route_table_association.public[1] will be created
  + resource "aws_route_table_association" "public" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.subnets.aws_subnet.private[0] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-south-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "172.16.0.0/19"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1a"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all                                       = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1a"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.subnets.aws_subnet.private[1] will be created
  + resource "aws_subnet" "private" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-south-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "172.16.32.0/19"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1b"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all                                       = {
          + "Attributes"                          = "cluster-private"
          + "Name"                                = "nomad-cluster-private-aps1b"
          + "cpco.io/subnet/type"                 = "private"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.subnets.aws_subnet.public[0] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-south-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "172.16.96.0/19"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public-aps1a"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all                                       = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public-aps1a"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.subnets.aws_subnet.public[1] will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "ap-south-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "172.16.128.0/19"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public-aps1b"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all                                       = {
          + "Attributes"                          = "cluster-public"
          + "Name"                                = "nomad-cluster-public-aps1b"
          + "cpco.io/subnet/type"                 = "public"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_default_security_group.default[0] will be created
  + resource "aws_default_security_group" "default" {
      + arn                    = (known after apply)
      + description            = (known after apply)
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Attributes"                          = "cluster"
          + "Name"                                = "Default Security Group"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all               = {
          + "Attributes"                          = "cluster"
          + "Name"                                = "Default Security Group"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id                 = (known after apply)
    }

  # module.vpc.aws_internet_gateway.default[0] will be created
  + resource "aws_internet_gateway" "default" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags     = {
          + "Attributes"                          = "cluster"
          + "Name"                                = "nomad-cluster"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all = {
          + "Attributes"                          = "cluster"
          + "Name"                                = "nomad-cluster"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + vpc_id   = (known after apply)
    }

  # module.vpc.aws_vpc.default[0] will be created
  + resource "aws_vpc" "default" {
      + arn                                  = (known after apply)
      + assign_generated_ipv6_cidr_block     = true
      + cidr_block                           = "172.16.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = false
      + enable_classiclink_dns_support       = false
      + enable_dns_hostnames                 = true
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Attributes"                          = "cluster"
          + "Name"                                = "nomad-cluster"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
      + tags_all                             = {
          + "Attributes"                          = "cluster"
          + "Name"                                = "nomad-cluster"
          + "kubernetes.io/cluster/nomad-cluster" = "shared"
        }
    }

Plan: 41 to add, 0 to change, 0 to destroy.
```

**Output:**
<img width="908" alt="Screenshot 2022-01-24 at 9 31 46 AM" src="https://user-images.githubusercontent.com/15846947/150720083-ab5d7e63-aea6-435e-84b7-ab2371f854c9.png">